### PR TITLE
ci: removed goimports from ci check & applying gofmt

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,7 +6,6 @@ linters:
   enable:
     - deadcode
     - goconst
-    - goimports
     - gosimple
     - govet
     - ineffassign

--- a/x/gal/client/cli/tx.go
+++ b/x/gal/client/cli/tx.go
@@ -78,7 +78,7 @@ When using '--dry-run' a key name cannot be used, only a bech32 address.`,
 			if err := cmd.Flags().Set("to", args[0]); err != nil {
 				return err
 			}
-			
+
 			clientCtx, err := client.GetClientTxContext(cmd)
 			if err != nil {
 				return err

--- a/x/oracle/keeper/keeper.go
+++ b/x/oracle/keeper/keeper.go
@@ -2,8 +2,8 @@ package keeper
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
+
 	"github.com/Carina-labs/nova/x/oracle/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
@@ -54,7 +54,7 @@ func (k Keeper) GetChainState(ctx sdk.Context, chainDenom string) (*types.QueryS
 	store := ctx.KVStore(k.storeKey)
 	if !store.Has([]byte(chainDenom)) {
 		// TODO : aggregate errors to types
-		return nil, errors.New(fmt.Sprintf("%s is not supported.", chainDenom))
+		return nil, fmt.Errorf("%s is not supported", chainDenom)
 	}
 
 	result := make(map[string]uint64)


### PR DESCRIPTION
gofmt 적용 및 goimports는 ci에서 제거했습니다. 

1. goimports 를 CI에서 제거했습니다.
2. gofmt를 파일별로 적용했고 go security checker 통과를 위해 몇 가지 수정했습니다.
    1. 모든 에러 핸들링은 한다고 생각해주세요. error 를 리턴하는 함수가 있는데, 코드에서 에러를 다루지 않으면 안됩니다.
3. `nullify.go`는 쓰지 않을 것 같아서 제거했습니다.