### PR TITLE
fix: impl invalid denom

### DIFF
--- a/x/gal/keeper/msg_server.go
+++ b/x/gal/keeper/msg_server.go
@@ -41,6 +41,10 @@ func (m msgServer) Deposit(goCtx context.Context, deposit *types.MsgDeposit) (*t
 		return nil, err
 	}
 
+	if deposit.Amount.Denom != m.keeper.ibcstakingKeeper.GetIBCHashDenom(ctx, deposit.TransferPortId, deposit.TransferChannelId, zoneInfo.BaseDenom) {
+		return nil, types.ErrInvalidDenom
+	}
+
 	newRecord := &types.DepositRecordContent{
 		Amount: &deposit.Amount,
 		State:  int64(DEPOSIT_REQUEST),

--- a/x/gal/types/errors.go
+++ b/x/gal/types/errors.go
@@ -12,4 +12,5 @@ var (
 	ErrInvalidTime         = errors.Register(ModuleName, 6, "time is not zero")
 	ErrCanNotChangeState   = errors.Register(ModuleName, 7, "cannot change state")
 	ErrDelegateFail        = errors.Register(ModuleName, 8, "delegate fail")
+	ErrInvalidDenom        = errors.Register(ModuleName, 9, "invalid denom")
 )


### PR DESCRIPTION
사용자가 deposit 요청시 잘못된 denom의 token을 전송하면 deposit되지 않도록 예외 처리했습니다.