### PR TITLE
chore: refactored for clear definition

### DIFF
--- a/x/gal/keeper/ibc_transfer.go
+++ b/x/gal/keeper/ibc_transfer.go
@@ -8,23 +8,30 @@ import (
 	ibcclienttypes "github.com/cosmos/ibc-go/v3/modules/core/02-client/types"
 )
 
+type IBCTransferOption struct {
+	SourcePort    string
+	SourceChannel string
+	Token         sdk.Coin
+	Sender        string
+	Receiver      string
+}
+
 // TransferToTargetZone transfers user's asset to target zone(Host chain)
 // using IBC transfer.
-func (k Keeper) TransferToTargetZone(ctx sdk.Context,
-	sourcePort, sourceChannel, depositor, icaController string, amt sdk.Coin) error {
+func (k Keeper) TransferToTargetZone(ctx sdk.Context, option *IBCTransferOption) error {
 	goCtx := sdk.WrapSDKContext(ctx)
-	depositorAddr, err := sdk.AccAddressFromBech32(depositor)
+	sender, err := sdk.AccAddressFromBech32(option.Sender)
 	if err != nil {
 		return err
 	}
 
 	_, err = k.ibcTransferKeeper.Transfer(goCtx,
 		&transfertypes.MsgTransfer{
-			SourcePort:    sourcePort,
-			SourceChannel: sourceChannel,
-			Token:         amt,
-			Sender:        depositorAddr.String(),
-			Receiver:      icaController,
+			SourcePort:    option.SourcePort,
+			SourceChannel: option.SourceChannel,
+			Token:         option.Token,
+			Sender:        sender.String(),
+			Receiver:      option.Receiver,
 			TimeoutHeight: ibcclienttypes.Height{
 				RevisionHeight: 0,
 				RevisionNumber: 0,

--- a/x/gal/keeper/msg_server.go
+++ b/x/gal/keeper/msg_server.go
@@ -70,12 +70,14 @@ func (m msgServer) Deposit(goCtx context.Context, deposit *types.MsgDeposit) (*t
 		m.keeper.SetDepositAmt(ctx, record)
 	}
 
-	err = m.keeper.TransferToTargetZone(ctx,
-		deposit.TransferPortId,
-		deposit.TransferChannelId,
-		deposit.Depositor,
-		zoneInfo.IcaAccount.HostAddress,
-		deposit.Amount)
+	err = m.keeper.TransferToTargetZone(ctx, &IBCTransferOption{
+		SourcePort:    deposit.TransferPortId,
+		SourceChannel: deposit.TransferChannelId,
+		Token:         deposit.Amount,
+		Sender:        deposit.Depositor,
+		Receiver:      zoneInfo.IcaAccount.HostAddress,
+	})
+
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- IBC Transfer 함수는 순수하게 IBC Transfer맥락에서만 동작하는 독립적인 기능
  - 내부에 depositor라는 변수명이 맥락을 해침
  - parameter가 많아짐에 따라 압축함
    - 파라미터가 많아지면 함수 원형만 보고 2번째 파라미터가 뭐고 이런게 추측이 안됨
    - e.g. `transfer(depositor, ica_address)` -> `transfer(sender: depositor, receiver: ica_address)`